### PR TITLE
Emmiting comments && holding information about SQL syntax used

### DIFF
--- a/lib/ronin/code/sql/emitter.rb
+++ b/lib/ronin/code/sql/emitter.rb
@@ -42,6 +42,9 @@ module Ronin
         # Generate DB-specific code
         attr_reader :syntax
 
+        # String to use as 'comment' or :auto to let the emitter decide
+        attr_reader :comment
+
         #
         # Initializes the SQL Emitter.
         #
@@ -51,18 +54,23 @@ module Ronin
         # @param [:single, :double] quotes
         #   Type of quotes to use for Strings.
         #
+        # @param [:unset, :mysql, :postgres, :oracle, :mssql] syntax
+        #   Syntax used during code-generation
+        #
+        # @param [:auto, String] comment
+        #   String to use as the comment when terminating injection string
+        #
         # @param [Hash{Symbol => Object}] kwargs
         #   Emitter options.
         #
         # @option kwargs [:lower, :upper, :random, nil] :case
         #   Case for keywords.
         #
-        # @option kwargs [:unset, :mysql, :postgres, :oracle, :mssql] :syntax
-        #   Syntax used during code-generation
-        #
-        def initialize(space: ' ', quotes: :single, **kwargs)
+
+        def initialize(space: ' ', quotes: :single, syntax: :unset, comment: :auto, **kwargs)
           @case   = kwargs[:case] # HACK: because `case` is a ruby keyword
-          @syntax = syntax || :unset
+          @syntax = syntax
+          @comment = comment
           @space  = space
           @quotes = quotes
         end
@@ -146,8 +154,9 @@ module Ronin
         #   The raw SQL.
         #
         def emit_comment
-          # -- works everywhere no need to include syntax-dependent code
-          '-- '
+          return '-- ' if @comment == :auto # -- works everywhere no need to include syntax-dependent code
+
+          @comment # Comment provided by user - use it
         end
 
         #

--- a/lib/ronin/code/sql/emitter.rb
+++ b/lib/ronin/code/sql/emitter.rb
@@ -39,6 +39,9 @@ module Ronin
         # Type of String quotes to use
         attr_reader :quotes
 
+        # Generate DB-specific code
+        attr_reader :syntax
+
         #
         # Initializes the SQL Emitter.
         #
@@ -54,8 +57,12 @@ module Ronin
         # @option kwargs [:lower, :upper, :random, nil] :case
         #   Case for keywords.
         #
+        # @option kwargs [:unset, :mysql, :postgres, :oracle, :mssql] :syntax
+        #   Syntax used during code-generation
+        #
         def initialize(space: ' ', quotes: :single, **kwargs)
           @case   = kwargs[:case] # HACK: because `case` is a ruby keyword
+          @syntax = syntax || :unset
           @space  = space
           @quotes = quotes
         end
@@ -139,7 +146,8 @@ module Ronin
         #   The raw SQL.
         #
         def emit_comment
-          '--'
+          # -- works everywhere no need to include syntax-dependent code
+          '-- '
         end
 
         #

--- a/lib/ronin/code/sql/emitter.rb
+++ b/lib/ronin/code/sql/emitter.rb
@@ -133,6 +133,16 @@ module Ronin
         end
 
         #
+        # Emits a SQL comment.
+        #
+        # @return [String]
+        #   The raw SQL.
+        #
+        def emit_comment
+          '--'
+        end
+
+        #
         # Emits a SQL Integer.
         #
         # @param [Integer] int

--- a/lib/ronin/code/sql/emitter.rb
+++ b/lib/ronin/code/sql/emitter.rb
@@ -42,7 +42,7 @@ module Ronin
         # Generate DB-specific code
         attr_reader :syntax
 
-        # String to use as 'comment' or :auto to let the emitter decide
+        # String to use as 'comment' or `nil` to let the emitter decide
         attr_reader :comment
 
         #
@@ -54,10 +54,10 @@ module Ronin
         # @param [:single, :double] quotes
         #   Type of quotes to use for Strings.
         #
-        # @param [:unset, :mysql, :postgres, :oracle, :mssql] syntax
+        # @param [nil, :mysql, :postgres, :oracle, :mssql] syntax
         #   Syntax used during code-generation
         #
-        # @param [:auto, String] comment
+        # @param [nil, String] comment
         #   String to use as the comment when terminating injection string
         #
         # @param [Hash{Symbol => Object}] kwargs
@@ -67,12 +67,12 @@ module Ronin
         #   Case for keywords.
         #
 
-        def initialize(space: ' ', quotes: :single, syntax: :unset, comment: :auto, **kwargs)
-          @case   = kwargs[:case] # HACK: because `case` is a ruby keyword
-          @syntax = syntax
+        def initialize(space: ' ', quotes: :single, syntax: nil, comment: nil, **kwargs)
+          @case    = kwargs[:case] # HACK: because `case` is a ruby keyword
+          @syntax  = syntax
           @comment = comment
-          @space  = space
-          @quotes = quotes
+          @space   = space
+          @quotes  = quotes
         end
 
         #
@@ -154,9 +154,8 @@ module Ronin
         #   The raw SQL.
         #
         def emit_comment
-          return '-- ' if @comment == :auto # -- works everywhere no need to include syntax-dependent code
-
-          @comment # Comment provided by user - use it
+          # Return chosen comment or default one which works everywhere
+          @comment || '-- '
         end
 
         #

--- a/lib/ronin/code/sql/injection.rb
+++ b/lib/ronin/code/sql/injection.rb
@@ -145,7 +145,7 @@ module Ronin
           when :string, :list
             if (terminate || (sql[0,1] != sql[-1,1]))
               # terminate the expression
-              sql << ';--'
+              sql << ';' << emitter.emit_comment
             else
               sql = sql[0..-2]
             end
@@ -155,7 +155,7 @@ module Ronin
           else
             if terminate
               # terminate the expression
-              sql << ';--'
+              sql << ';' << emitter.emit_comment
             end
           end
 

--- a/spec/sql/emitter_spec.rb
+++ b/spec/sql/emitter_spec.rb
@@ -107,6 +107,12 @@ describe Ronin::Code::SQL::Emitter do
     end
   end
 
+  describe "#emit_comment" do
+    it "should emit a String" do
+      expect(subject.emit_comment).to eq('--')
+    end
+  end
+
   describe "#emit_integer" do
     it "should emit a String" do
       expect(subject.emit_integer(10)).to eq('10')

--- a/spec/sql/emitter_spec.rb
+++ b/spec/sql/emitter_spec.rb
@@ -12,7 +12,9 @@ describe Ronin::Code::SQL::Emitter do
     context "without options" do
       it { expect(subject.space).to  eq(' ')     }
       it { expect(subject.quotes).to eq(:single) }
+      it { expect(subject.syntax).to eq(:unset)  }
     end
+
   end
 
   describe "#emit_keyword" do
@@ -108,8 +110,41 @@ describe Ronin::Code::SQL::Emitter do
   end
 
   describe "#emit_comment" do
-    it "should emit a String" do
-      expect(subject.emit_comment).to eq('--')
+    context "when :syntax is :unset" do
+      it "should emit a comment that works everywhere '-- '" do
+        expect(subject.emit_comment).to start_with('-- ')
+      end
+    end
+
+    context "when :syntax is :mysql" do
+      subject { described_class.new(syntax: :mysql) }
+
+      it "should emit a MySQL/MariaDB-compatible comment that starts with '-- ' or '#'" do
+        expect(subject.emit_comment).to start_with('-- ').or start_with('#')
+      end
+    end
+
+    context "when :syntax is :postgres" do
+      subject { described_class.new(syntax: :postgres) }
+      it "should emit a Postgres-compatible comment that starts with '--'" do
+        expect(subject.emit_comment).to start_with('--')
+      end
+    end
+
+    context "when :syntax is :oracle" do
+      subject { described_class.new(syntax: :oracle) }
+
+      it "should emit a Oracle-compatible comment that starts with '--'" do
+        expect(subject.emit_comment).to start_with('--')
+      end
+    end
+
+    context "when :syntax is :mssql" do
+      subject { described_class.new(syntax: :mssql) }
+
+      it "should emit a MSSQL-compatible comment that starts with '--'" do
+        expect(subject.emit_comment).to start_with('--')
+      end
     end
   end
 

--- a/spec/sql/emitter_spec.rb
+++ b/spec/sql/emitter_spec.rb
@@ -13,8 +13,40 @@ describe Ronin::Code::SQL::Emitter do
       it { expect(subject.space).to  eq(' ')     }
       it { expect(subject.quotes).to eq(:single) }
       it { expect(subject.syntax).to eq(:unset)  }
+      it { expect(subject.comment).to eq(:auto)  }
     end
 
+    context "provided :quotes" do
+      subject { described_class.new(quotes: 'test_quotes') }
+
+      it 'is expected to hold it' do
+        expect(subject.quotes).to eq('test_quotes')
+      end
+    end
+
+    context "provided :space" do
+      subject { described_class.new(space: '# test-space #') }
+
+      it 'is expected to hold it' do
+        expect(subject.space).to eq('# test-space #')
+      end
+    end
+
+    context "provided :syntax" do
+      subject { described_class.new(syntax: :test_syntax) }
+
+      it 'is expected to hold it' do
+        expect(subject.syntax).to eq(:test_syntax)
+      end
+    end
+
+    context "provided :comment" do
+      subject { described_class.new(comment: '<!-- test comment ') }
+
+      it 'is expected to hold it' do
+        expect(subject.comment).to eq('<!-- test comment ')
+      end
+    end
   end
 
   describe "#emit_keyword" do
@@ -110,40 +142,51 @@ describe Ronin::Code::SQL::Emitter do
   end
 
   describe "#emit_comment" do
-    context "when :syntax is :unset" do
-      it "should emit a comment that works everywhere '-- '" do
-        expect(subject.emit_comment).to start_with('-- ')
+    context "when :comment is set to specific value" do
+      let(:custom_comment) { '# -- /* custom comment ' }
+      subject { described_class.new(comment: custom_comment) }
+
+      it 'should use that value' do
+        expect(subject.emit_comment).to eq(custom_comment)
       end
     end
 
-    context "when :syntax is :mysql" do
-      subject { described_class.new(syntax: :mysql) }
-
-      it "should emit a MySQL/MariaDB-compatible comment that starts with '-- ' or '#'" do
-        expect(subject.emit_comment).to start_with('-- ').or start_with('#')
+    context "when :comment is not set(defaulted to :auto)" do
+      context "when :syntax is :unset" do
+        it "should emit a comment that works everywhere '-- '" do
+          expect(subject.emit_comment).to start_with('-- ')
+        end
       end
-    end
 
-    context "when :syntax is :postgres" do
-      subject { described_class.new(syntax: :postgres) }
-      it "should emit a Postgres-compatible comment that starts with '--'" do
-        expect(subject.emit_comment).to start_with('--')
+      context "when :syntax is :mysql" do
+        subject { described_class.new(syntax: :mysql) }
+
+        it "should emit a MySQL/MariaDB-compatible comment that starts with '-- ' or '#'" do
+          expect(subject.emit_comment).to start_with('-- ').or start_with('#')
+        end
       end
-    end
 
-    context "when :syntax is :oracle" do
-      subject { described_class.new(syntax: :oracle) }
-
-      it "should emit a Oracle-compatible comment that starts with '--'" do
-        expect(subject.emit_comment).to start_with('--')
+      context "when :syntax is :postgres" do
+        subject { described_class.new(syntax: :postgres) }
+        it "should emit a Postgres-compatible comment that starts with '--'" do
+          expect(subject.emit_comment).to start_with('--')
+        end
       end
-    end
 
-    context "when :syntax is :mssql" do
-      subject { described_class.new(syntax: :mssql) }
+      context "when :syntax is :oracle" do
+        subject { described_class.new(syntax: :oracle) }
 
-      it "should emit a MSSQL-compatible comment that starts with '--'" do
-        expect(subject.emit_comment).to start_with('--')
+        it "should emit a Oracle-compatible comment that starts with '--'" do
+          expect(subject.emit_comment).to start_with('--')
+        end
+      end
+
+      context "when :syntax is :mssql" do
+        subject { described_class.new(syntax: :mssql) }
+
+        it "should emit a MSSQL-compatible comment that starts with '--'" do
+          expect(subject.emit_comment).to start_with('--')
+        end
       end
     end
   end

--- a/spec/sql/emitter_spec.rb
+++ b/spec/sql/emitter_spec.rb
@@ -12,8 +12,8 @@ describe Ronin::Code::SQL::Emitter do
     context "without options" do
       it { expect(subject.space).to  eq(' ')     }
       it { expect(subject.quotes).to eq(:single) }
-      it { expect(subject.syntax).to eq(:unset)  }
-      it { expect(subject.comment).to eq(:auto)  }
+      it { expect(subject.syntax).to be_nil  }
+      it { expect(subject.comment).to be_nil  }
     end
 
     context "provided :quotes" do

--- a/spec/sql/injection_spec.rb
+++ b/spec/sql/injection_spec.rb
@@ -140,7 +140,7 @@ describe Ronin::Code::SQL::Injection do
         end 
 
         it "should terminate the SQL statement" do
-          expect(subject.to_sql).to eq("1' OR 1=1;--")
+          expect(subject.to_sql).to start_with("1' OR 1=1;-- ")
         end
       end
 
@@ -152,7 +152,7 @@ describe Ronin::Code::SQL::Injection do
         end 
 
         it "should terminate the SQL statement" do
-          expect(subject.to_sql(terminate: true)).to eq("1' OR '1'='1';--")
+          expect(subject.to_sql(terminate: true)).to start_with("1' OR '1'='1';-- ")
         end
       end
     end
@@ -165,7 +165,7 @@ describe Ronin::Code::SQL::Injection do
       end 
 
       it "should terminate the SQL statement" do
-        expect(subject.to_sql(terminate: true)).to eq("1 OR 1=1;--")
+        expect(subject.to_sql(terminate: true)).to start_with("1 OR 1=1;-- ")
       end
     end
   end


### PR DESCRIPTION
Solves #15 #16 #17.

Latest commit(#85c0095) also fixes a bug found in `syntax` implementation and includes additional tests to prevent regression.